### PR TITLE
Added a container around the wcag icon and set that to block instead …

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -61,9 +61,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/a11y.html
+++ b/public/a11y.html
@@ -499,9 +499,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/blog.html
+++ b/public/blog.html
@@ -146,9 +146,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/contact.html
+++ b/public/contact.html
@@ -70,9 +70,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -208,6 +208,7 @@ header nav a {
     align-content: left;
     display:flex;
     font-weight: bold;
+    min-height: 5px;
 }
 
 .breadcrumbs nav {
@@ -313,6 +314,6 @@ footer ul {
     padding: 0;
 }
 
-#wcagIcon {
+#wcagIconContainer {
     display: block;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -36,11 +36,12 @@
                 </ul>
             </nav>
         </header>
-        <nav class="breadcrumbs" aria-label="Navigation Breadcrumbs">
+        <div class="breadcrumbs"></div>
+        <!-- <nav class="breadcrumbs" aria-label="Navigation Breadcrumbs">
             <ul>
                 <li><a href="index.html"><i class="fa-solid fa-house fa-lg" id="navHouse"></i><span class="sr-only">Home</span></a></li>
             </ul>
-        </nav>
+        </nav> -->
         <div id="wrapper">
             <main>
                 <h1 class="mainHeadline">Welcome to CorgiDev!</h1>
@@ -137,9 +138,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/resume.html
+++ b/public/resume.html
@@ -274,9 +274,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>

--- a/public/resume/AdditionalExperience.html
+++ b/public/resume/AdditionalExperience.html
@@ -435,9 +435,11 @@
                     </ul>
                 </nav>
                 <p>Website created and maintained by Erissa Duvall aka CorgiDev since 2017.</p>
-                <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
-                    <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
-                </a>
+                <div id="wcagIconContainer">
+                    <a href="https://www.w3.org/WAI/WCAG2AA-Conformance" id="wcagIcon" title="Explanation of WCAG 2 Level AA conformance">
+                        <img height="32" width="88" src="https://www.w3.org/WAI/WCAG21/wcag2.1AA-v" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.1">
+                    </a>
+                </div>
             </footer>
         </div>
         <script src="https://kit.fontawesome.com/57e0b881dd.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Added a container around the linked WCAG image in the footer. Set that to blocked instead of the linked image.
- This ensures it doesn't get positioned weird.
- Also ensures the hover/tab focus indicator doesn't expand to the whole width of the page.

Removed the breadcrumb nav from the home page since it was not necessary there.

Kept a bit of the bar that it would normally sit in to give a bit of a shadow to the header that appears to expand when you go to other pages.